### PR TITLE
Many improvements to retro-proxy

### DIFF
--- a/example.env
+++ b/example.env
@@ -20,6 +20,14 @@ NO_CSS=true
 #for pages that you want Javascript on.
 NO_JS=true
 
+#Block `Cookie` and `Set-Cookie` headers.
+#retro-proxy turns "secure" cookie header attributes into regular ones,
+#which may be a security risk, as the browser may then send the cookie in a
+#later "insecure" request. (See RFC 6265, section 4.1.2.5)
+#Some sites are dependent on cookies for login and sessions to work correctly.
+#If you trust those and accept the risk, set this to 'false' instead.
+NO_COOKIES=true
+
 #Resize and compress image files. 
 #Smaller screeens or smaller amounts of RAM really benefit from this, but it 
 #prevents you from downloading the full-quality images.

--- a/index.js
+++ b/index.js
@@ -166,6 +166,8 @@ app.all("*", async (req, res, next) => {
               imgs.push(this);
             }
           });
+          //remove inline SVG as well
+          $("svg").remove();
 
           if (maxInlineWidth) {
             //set image tag sizes

--- a/index.js
+++ b/index.js
@@ -228,6 +228,17 @@ app.all("*", async (req, res, next) => {
           const href = $(element).attr('href');
           $(this).attr('href',new URL(url).origin+href);
         });
+        // HACK to fix oauth - redirect_uri in a form field must be https
+        $("input").each(function(index,element) {
+          if ($(element).attr('id') === 'redirect_uri') {
+            let redirect_uri = new URL($(element).attr('value'));
+            if (forceSecureHosts.some((f) => redirect_uri.hostname.endsWith(f))) {
+              redirect_uri.protocol = 'https';
+              $(this).attr('value', redirect_uri.href);
+            }
+          }
+        });
+
         res.set("Content-Type", "text/html");
         res.status(upstream.status);
         if (!friendly) {


### PR DESCRIPTION
I was able to use retro-proxy to make a post to my Mastodon instance using IE 5 on Windows 3.11, with the third-party service brutaldon.org (a Web 1.0 client to Mastodon's API): https://icosahedron.website/@greg/114168115837895064

However, getting this working required a lot of enhancements to retro-proxy, which I'm now putting in a PR :)

Specifically:
* "Manual" redirect mode, which sends 301/302 redirects back to the client, instead of following "automatically" in fetch
  * This also fixes the problem of the wrong root for e.g. http://example.com/directory (missing trailing slash), causing browsers to see "http://example.com/" as the root.  Remote servers usually issue a redirect to directory/ but unless the client gets this info, it makes wrong requests.
* Forward certain headers from client back to upstream - Referer is usually needed, but also Accept-Encoding and others
* Support POST / PATCH / DELETE / etc. beyond just GET (and adds support for reading / forwarding request body contents)
* `Cookie` / `Set-Cookie` header passing, allowing the client to send cookies to upstream
* A hack to support OAuth by correcting the redirect_uri <input> in the authorization <form>.  This could probably be removed if retro-proxy went back from text-wide https: replacement and instead targeted specific HTML entities.

Somewhere in here I added attempted auto-detection of sites which force HTTPS, by looking for a redirect from http://<website> to https://<website>.  It's not 100% correct, I know it falls over on http://bsky.app for example (because their redirect comes with :443 port appended) but it is a start.

Also I added blanket removal of SVG elements (since they're already stripped by <img {svg}> but the big inline svg my instance kept serving irritated me haha